### PR TITLE
Feat/array data type support

### DIFF
--- a/dataframe_show_reader/dataframe_show_reader.py
+++ b/dataframe_show_reader/dataframe_show_reader.py
@@ -15,8 +15,8 @@
 from datetime import datetime
 from pyspark.sql import DataFrame, SparkSession
 from pyspark.sql import Row
-from pyspark.sql.types import (ArrayType, BooleanType, DoubleType, FloatType, IntegerType,
-                               LongType, StringType, StructType, StructField, TimestampType)
+from pyspark.sql.types import (ArrayType, BooleanType, DoubleType, IntegerType, LongType,
+                               StringType, StructType, StructField, TimestampType)
 
 
 DATA_TYPE_START_INDICATOR = '['
@@ -233,7 +233,7 @@ _TYPE_MAP = {
     'array_str': (str_array, ArrayType(StringType())),
     'array_int': (int_array, ArrayType(IntegerType())),
     'array_double': (float_array, ArrayType(DoubleType())),
-    'array_float': (float_array, ArrayType(FloatType())),
+    'array_float': (float_array, ArrayType(DoubleType())),
     'array_array_str': (str_array_of_array, ArrayType(ArrayType(StringType()))),
     'array_array_int': (int_array_of_array, ArrayType(ArrayType(IntegerType()))),
     'array_array_double': (float_array_of_array, ArrayType(ArrayType(DoubleType()))),

--- a/dataframe_show_reader/dataframe_show_reader.py
+++ b/dataframe_show_reader/dataframe_show_reader.py
@@ -241,14 +241,14 @@ _TYPE_MAP = {
     'int': (int, IntegerType()),
     'string': (str, StringType()),
     'timestamp': (ts, TimestampType()),
-    'array_str': (str_array, ArrayType(StringType())),
-    'array_int': (int_array, ArrayType(IntegerType())),
-    'array_double': (float_array, ArrayType(DoubleType())),
-    'array_float': (float_array, ArrayType(DoubleType())),
-    'array_array_str': (str_array_of_array, ArrayType(ArrayType(StringType()))),
-    'array_array_int': (int_array_of_array, ArrayType(ArrayType(IntegerType()))),
-    'array_array_double': (float_array_of_array, ArrayType(ArrayType(DoubleType()))),
-    'array_array_float': (float_array_of_array, ArrayType(ArrayType(DoubleType()))),
+    'array<string>': (str_array, ArrayType(StringType())),
+    'array<int>': (int_array, ArrayType(IntegerType())),
+    'array<double>': (float_array, ArrayType(DoubleType())),
+    'array<float>': (float_array, ArrayType(DoubleType())),
+    'array<array<string>>': (str_array_of_array, ArrayType(ArrayType(StringType()))),
+    'array<array<int>>': (int_array_of_array, ArrayType(ArrayType(IntegerType()))),
+    'array<array<double>>': (float_array_of_array, ArrayType(ArrayType(DoubleType()))),
+    'array<array<float>>': (float_array_of_array, ArrayType(ArrayType(DoubleType()))),
 }
 
 

--- a/dataframe_show_reader/dataframe_show_reader.py
+++ b/dataframe_show_reader/dataframe_show_reader.py
@@ -19,8 +19,8 @@ from pyspark.sql.types import (ArrayType, BooleanType, DoubleType, FloatType, In
                                LongType, StringType, StructType, StructField, TimestampType)
 
 
-DATA_TYPE_START_INDICATOR = '{'
-DATA_TYPE_END_INDICATOR = '}'
+DATA_TYPE_START_INDICATOR = '['
+DATA_TYPE_END_INDICATOR = ']'
 
 ARRAY_ELEMENT_START_INDICATOR = '['
 ARRAY_ELEMENT_END_INDICATOR = ']'
@@ -45,10 +45,10 @@ def show_output_to_df(show_output: str, spark_session: SparkSession):
     |value 2a|value 2b|
 
     Optionally, data types can be specified in a second header line (prefixed
-    with the DATA_TYPE_START_INDICATOR "{") :
+    with the DATA_TYPE_START_INDICATOR "[") :
     +-------------+----------+------------+-------------------+-----------+
     |string_column|int_column|float_column|timestamp_column   |bool_column|
-    {string       |int       |float       |timestamp          |boolean    }
+    [string       |int       |float       |timestamp          |boolean    ]
     +-------------+----------+------------+-------------------+-----------+
     |one          |1         |1.1         |2018-01-01 00:00:00|true       |
     |two          |2         |2.2         |2018-01-02 12:34:56|false      |
@@ -80,7 +80,7 @@ def show_output_to_df(show_output: str, spark_session: SparkSession):
             column_names = values
             continue
         elif types == None and line.startswith(f'{DATA_TYPE_START_INDICATOR}'):
-            line = line.replace(f'{DATA_TYPE_START_INDICATOR}', '|').replace(f'{DATA_TYPE_END_INDICATOR}', '|')
+            line = line.replace(f'{DATA_TYPE_START_INDICATOR}', '|', 1).rstrip(f'{DATA_TYPE_END_INDICATOR}|') + '|'
             types = [part.strip() for part in line.split('|')[1:-1]]
             schema = _get_schema(column_names, types)
             continue

--- a/tests/test_dataframe_show_reader.py
+++ b/tests/test_dataframe_show_reader.py
@@ -79,7 +79,7 @@ class TestDFUtil:
         rows = show_output_to_df("""
             +-------------+----------+-------------+------------+-------------------+-------------------+-----------+
             |string_column|int_column|bigint_column|float_column|timestamp_column   |default_type_column|bool_column|
-            {string       |int       |bigint       |float       |timestamp          |                   |boolean    }
+            [string       |int       |bigint       |float       |timestamp          |                   |boolean    ]
             +-------------+----------+-------------+------------+-------------------+-------------------+-----------+
             |one          |1         |1            |1.1         |2018-01-01 00:00:00|11                 |true       |
             |two          |2         |2            |2.2         |2018-01-02 12:34:56|22                 |false      |
@@ -113,7 +113,7 @@ class TestDFUtil:
         rows = show_output_to_df("""
             +-------------+----------+-------------+------------+-------------------+-------------------+-----------+
             |string_column|int_column|bigint_column|float_column|timestamp_column   |default_type_column|bool_column|
-            {string       |int       |bigint       |float       |timestamp          |                   |boolean    }
+            [string       |int       |bigint       |float       |timestamp          |                   |boolean    ]
             +-------------+----------+-------------+------------+-------------------+-------------------+-----------+
             |null         |null      |null         |null        |null               |null               |null       |
             +-------------+----------+-------------+------------+-------------------+-------------------+-----------+
@@ -135,7 +135,7 @@ class TestDFUtil:
         df = show_output_to_df("""
             +----+-------------+-------------+----------------+----------------+----------------------+
             |id  |array_str_col|array_int_col|array_float_col |array_double_col|array_array_float_col |
-            {int |array_str    |array_int    |array_float     |array_double    |array_array_float     }
+            [int |array_str    |array_int    |array_float     |array_double    |array_array_float     ]
             +----+-------------+-------------+----------------+----------------+----------------------+
             |1   |[hi,bye]     |[0,1,2]      |[0,1,2.0]       |[0,1,2.0]       |[[1,2],[1.0],[]]      |
             |2   |[]           |[]           |[]              |[]              |[]                    |

--- a/tests/test_dataframe_show_reader.py
+++ b/tests/test_dataframe_show_reader.py
@@ -133,25 +133,25 @@ class TestDFUtil:
     def test_show_output_to_df_with_arrays(self,
                                            spark_session: SparkSession):
         df = show_output_to_df("""
-            +----+-------------+-------------+----------------+----------------+----------------------+
-            |id  |array_str_col|array_int_col|array_float_col |array_double_col|array_array_float_col |
-            [int |array_str    |array_int    |array_float     |array_double    |array_array_float     ]
-            +----+-------------+-------------+----------------+----------------+----------------------+
-            |1   |[hi,bye]     |[0,1,2]      |[0,1,2.0]       |[0,1,2.0]       |[[1,2],[1.0],[]]      |
-            |2   |[]           |[]           |[]              |[]              |[]                    |
-            +----+-------------+-------------+----------------+----------------+----------------------+
-        """, spark_session)
-
+                    +----+--------------------+-------------+----------------+----------------+----------------------+-------------------------------+
+                    |id  |array_str_col       |array_int_col|array_float_col |array_double_col|array_array_float_col |array_array_str_col            |
+                    [int |array_str           |array_int    |array_float     |array_double    |array_array_float     |array_array_str                ]
+                    +----+--------------------+-------------+----------------+----------------+----------------------+-------------------------------+
+                    |1   |[ hi ,bye, so long ]|[0,  1 ,2 ]  |[0, 1, 2.0]     |[0, 1, 2.0]     |[[1, 2],[1.0],[]]     |[[ hi , bye, so long ],[yo],[]]|
+                    |2   |[  ]                |[     ]      |[]              |[]              |[]                    |[]                             |
+                    +----+--------------------+-------------+----------------+----------------+----------------------+-------------------------------+
+                """, spark_session)
         rows = df.collect()
         assert 2 == len(rows)
-        assert 6 == len(rows[0])  # Number of columns
+        assert 7 == len(rows[0])  # Number of columns
 
-        assert 1                     == rows[0]['id']
-        assert ['hi','bye']          == rows[0]['array_str_col']
-        assert [0,1,2]               == rows[0]['array_int_col']
-        assert [0.0, 1.0, 2.0]       == rows[0]['array_float_col']
-        assert [0.0, 1.0, 2.0]       == rows[0]['array_double_col']
-        assert [[1.0, 2.0],[1.0],[]] == rows[0]['array_array_float_col']
+        assert 1                                  == rows[0]['id']
+        assert ['hi','bye','so long']             == rows[0]['array_str_col']
+        assert [0,1,2]                            == rows[0]['array_int_col']
+        assert [0.0, 1.0, 2.0]                    == rows[0]['array_float_col']
+        assert [0.0, 1.0, 2.0]                    == rows[0]['array_double_col']
+        assert [[1.0, 2.0],[1.0],[]]              == rows[0]['array_array_float_col']
+        assert [['hi','bye','so long'],['yo'],[]] == rows[0]['array_array_str_col']
 
         assert 2                     == rows[1]['id']
         assert []                    == rows[1]['array_str_col']
@@ -159,3 +159,27 @@ class TestDFUtil:
         assert []                    == rows[1]['array_float_col']
         assert []                    == rows[1]['array_double_col']
         assert [[]]                  == rows[1]['array_array_float_col']
+        assert [[]]                  == rows[1]['array_array_str_col']
+
+    def test_show_output_to_df_with_wrapped_arrays(self,
+                                                   spark_session: SparkSession):
+        df = show_output_to_df("""
+                +---+-----------------------------------------------------------+------------------------------------------------------------------+
+                |id |array_array_float_col                                      |array_array_str_col                                               |
+                [int|array_array_float                                          |array_array_str                                                   |
+                +---+-----------------------------------------------------------+------------------------------------------------------------------+
+                |1  |[WrappedArray(1.0, 2.0), WrappedArray(1.0), WrappedArray()]|[WrappedArray(hi, bye, so long), WrappedArray(yo), WrappedArray()]|
+                |2  |[WrappedArray()]                                           |[WrappedArray()]                                                  |
+                +---+-----------------------------------------------------------+------------------------------------------------------------------+
+                """, spark_session)
+        rows = df.collect()
+        assert 2 == len(rows)
+        assert 3 == len(rows[0])  # Number of columns
+
+        assert 1                                  == rows[0]['id']
+        assert [[1.0, 2.0],[1.0],[]]              == rows[0]['array_array_float_col']
+        assert [['hi','bye','so long'],['yo'],[]] == rows[0]['array_array_str_col']
+
+        assert 2                     == rows[1]['id']
+        assert [[]]                  == rows[1]['array_array_float_col']
+        assert [[]]                  == rows[1]['array_array_str_col']

--- a/tests/test_dataframe_show_reader.py
+++ b/tests/test_dataframe_show_reader.py
@@ -79,7 +79,7 @@ class TestDFUtil:
         rows = show_output_to_df("""
             +-------------+----------+-------------+------------+-------------------+-------------------+-----------+
             |string_column|int_column|bigint_column|float_column|timestamp_column   |default_type_column|bool_column|
-            [string       |int       |bigint       |float       |timestamp          |                   |boolean    ]
+            {string       |int       |bigint       |float       |timestamp          |                   |boolean    }
             +-------------+----------+-------------+------------+-------------------+-------------------+-----------+
             |one          |1         |1            |1.1         |2018-01-01 00:00:00|11                 |true       |
             |two          |2         |2            |2.2         |2018-01-02 12:34:56|22                 |false      |
@@ -113,7 +113,7 @@ class TestDFUtil:
         rows = show_output_to_df("""
             +-------------+----------+-------------+------------+-------------------+-------------------+-----------+
             |string_column|int_column|bigint_column|float_column|timestamp_column   |default_type_column|bool_column|
-            [string       |int       |bigint       |float       |timestamp          |                   |boolean    ]
+            {string       |int       |bigint       |float       |timestamp          |                   |boolean    }
             +-------------+----------+-------------+------------+-------------------+-------------------+-----------+
             |null         |null      |null         |null        |null               |null               |null       |
             +-------------+----------+-------------+------------+-------------------+-------------------+-----------+
@@ -129,3 +129,33 @@ class TestDFUtil:
         assert None == row['timestamp_column']
         assert None == row['default_type_column']
         assert None == row['bool_column']
+
+    def test_show_output_to_df_with_arrays(self,
+                                           spark_session: SparkSession):
+        df = show_output_to_df("""
+            +----+-------------+-------------+----------------+----------------+----------------------+
+            |id  |array_str_col|array_int_col|array_float_col |array_double_col|array_array_float_col |
+            {int |array_str    |array_int    |array_float     |array_double    |array_array_float     }
+            +----+-------------+-------------+----------------+----------------+----------------------+
+            |1   |[hi,bye]     |[0,1,2]      |[0,1,2.0]       |[0,1,2.0]       |[[1,2],[1.0],[]]      |
+            |2   |[]           |[]           |[]              |[]              |[]                    |
+            +----+-------------+-------------+----------------+----------------+----------------------+
+        """, spark_session)
+
+        rows = df.collect()
+        assert 2 == len(rows)
+        assert 6 == len(rows[0])  # Number of columns
+
+        assert 1                     == rows[0]['id']
+        assert ['hi','bye']          == rows[0]['array_str_col']
+        assert [0,1,2]               == rows[0]['array_int_col']
+        assert [0.0, 1.0, 2.0]       == rows[0]['array_float_col']
+        assert [0.0, 1.0, 2.0]       == rows[0]['array_double_col']
+        assert [[1.0, 2.0],[1.0],[]] == rows[0]['array_array_float_col']
+
+        assert 2                     == rows[1]['id']
+        assert []                    == rows[1]['array_str_col']
+        assert []                    == rows[1]['array_int_col']
+        assert []                    == rows[1]['array_float_col']
+        assert []                    == rows[1]['array_double_col']
+        assert [[]]                  == rows[1]['array_array_float_col']


### PR DESCRIPTION
Add support for arrays and arrays of arrays.

- Changed the data type line start/end indicators from '[]' to '{}'
  so we can use the '[]' with the new array data types.

- These data types are now supported for both arrays and
  arrays of arrays: str, int, float, double